### PR TITLE
[context menu] Drive the open gesture by cursor movement instead of a timeout

### DIFF
--- a/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
@@ -195,14 +195,86 @@ describe('<ContextMenu.Root />', () => {
       await screen.findByTestId('context-popup');
       const item = screen.getByTestId('context-item');
 
-      fireEvent.pointerMove(document.body, { clientX: 24, clientY: 24 });
-      fireEvent.mouseUp(item, { button: 2, clientX: 24, clientY: 24 });
+      fireEvent.pointerMove(document.body, { clientX: 30, clientY: 30 });
+      fireEvent.mouseUp(item, { button: 2, clientX: 30, clientY: 30 });
 
       await waitFor(() => {
         expect(screen.queryByTestId('context-popup')).toBe(null);
       });
 
       expect(onOpenChange.mock.lastCall?.[0]).toBe(false);
+    });
+
+    it('closes when right-clicking again within the move threshold', async () => {
+      if (reactMajor <= 18) {
+        ignoreActWarnings();
+      }
+
+      const onOpenChange = vi.fn();
+
+      await render(
+        <ContextMenu.Root onOpenChange={onOpenChange}>
+          <ContextMenu.Trigger data-testid="context-trigger">Surface</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup data-testid="context-popup">
+                <ContextMenu.Item>Action</ContextMenu.Item>
+              </ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('context-trigger');
+
+      fireEvent.contextMenu(trigger, { clientX: 10, clientY: 10, button: 2 });
+      await screen.findByTestId('context-popup');
+
+      // While open, the modal backdrop covers the trigger, so the second right
+      // click lands on it. Right-clicking again within the 5x5px box toggles closed.
+      const backdrop = document.querySelector('[role="presentation"][data-base-ui-inert]')!;
+      fireEvent.contextMenu(backdrop, { clientX: 11, clientY: 12, button: 2 });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('context-popup')).toBe(null);
+      });
+
+      expect(onOpenChange.mock.lastCall?.[0]).toBe(false);
+    });
+
+    it('stays open when right-clicking again outside the move threshold', async () => {
+      if (reactMajor <= 18) {
+        ignoreActWarnings();
+      }
+
+      const onOpenChange = vi.fn();
+
+      await render(
+        <ContextMenu.Root onOpenChange={onOpenChange}>
+          <ContextMenu.Trigger data-testid="context-trigger">Surface</ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner>
+              <ContextMenu.Popup data-testid="context-popup">
+                <ContextMenu.Item>Action</ContextMenu.Item>
+              </ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>,
+      );
+
+      const trigger = screen.getByTestId('context-trigger');
+
+      fireEvent.contextMenu(trigger, { clientX: 10, clientY: 10, button: 2 });
+      await screen.findByTestId('context-popup');
+
+      // Right-clicking the backdrop far from the opening point does not toggle the
+      // menu closed.
+      const backdrop = document.querySelector('[role="presentation"][data-base-ui-inert]')!;
+      fireEvent.contextMenu(backdrop, { clientX: 80, clientY: 80, button: 2 });
+      await flushMicrotasks();
+
+      expect(screen.queryByTestId('context-popup')).not.toBe(null);
+      expect(onOpenChange.mock.calls.length).toBe(1);
     });
 
     it('does not open when disabled', async () => {

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
@@ -78,7 +78,7 @@ describe('<ContextMenu.Trigger />', () => {
     expect(onOpenChange.mock.lastCall?.[0]).toBe(true);
   });
 
-  it('does not cancel opening menu on mouseup after mousedown outside before 500ms', async () => {
+  it('does not cancel opening menu on mouseup within the move threshold', async () => {
     const onOpenChange = vi.fn();
 
     await render(
@@ -93,22 +93,20 @@ describe('<ContextMenu.Trigger />', () => {
     );
 
     const trigger = screen.getByTestId('trigger');
-    fireEvent.mouseDown(trigger);
-    fireEvent.contextMenu(trigger);
-
-    clock.tick(499);
+    fireEvent.mouseDown(trigger, { clientX: 10, clientY: 10 });
+    fireEvent.contextMenu(trigger, { clientX: 10, clientY: 10 });
 
     expect(onOpenChange.mock.calls.length).toBe(1);
     expect(onOpenChange.mock.lastCall?.[0]).toBe(true);
 
-    fireEvent.mouseUp(document.body);
-
-    clock.tick(1);
+    // Releasing within the 5x5px box around the opening point keeps the menu open,
+    // regardless of how long the button was held.
+    fireEvent.mouseUp(document.body, { clientX: 11, clientY: 12 });
 
     expect(onOpenChange.mock.calls.length).toBe(1);
   });
 
-  it('cancels opening menu on mouseup after mousedown outside after 500ms', async () => {
+  it('cancels opening menu on mouseup outside the move threshold', async () => {
     const onOpenChange = vi.fn();
 
     await render(
@@ -123,12 +121,12 @@ describe('<ContextMenu.Trigger />', () => {
     );
 
     const trigger = screen.getByTestId('trigger');
-    fireEvent.mouseDown(trigger);
-    fireEvent.contextMenu(trigger);
+    fireEvent.mouseDown(trigger, { clientX: 10, clientY: 10 });
+    fireEvent.contextMenu(trigger, { clientX: 10, clientY: 10 });
 
-    clock.tick(501);
-
-    fireEvent.mouseUp(document.body);
+    // Releasing outside the 5x5px box turns the gesture into a press-drag-release
+    // that dismisses the menu.
+    fireEvent.mouseUp(document.body, { clientX: 50, clientY: 50 });
 
     expect(onOpenChange.mock.calls.length).toBe(2);
     expect(onOpenChange.mock.lastCall?.[0]).toBe(false);

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.tsx
@@ -6,6 +6,7 @@ import { useTimeout } from '@base-ui/utils/useTimeout';
 import { contains, getTarget, stopEvent } from '../../floating-ui-react/utils';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useContextMenuRootContext } from '../root/ContextMenuRootContext';
+import { CONTEXT_MENU_MOVE_THRESHOLD } from '../utils/constants';
 import { useMenuRootContext } from '../../menu/root/MenuRootContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
@@ -45,8 +46,6 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
   const triggerRef = React.useRef<HTMLDivElement | null>(null);
   const touchPositionRef = React.useRef<{ x: number; y: number } | null>(null);
   const longPressTimeout = useTimeout();
-  const allowMouseUpTimeout = useTimeout();
-  const allowMouseUpRef = React.useRef(false);
 
   function handleLongPress(x: number, y: number, event: MouseEvent | TouchEvent) {
     const isTouchEvent = event.type.startsWith('touch');
@@ -64,12 +63,7 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
       },
     });
 
-    allowMouseUpRef.current = false;
     actionsRef.current?.setOpen(true, createChangeEventDetails(REASONS.triggerPress, event));
-
-    allowMouseUpTimeout.start(LONG_PRESS_DELAY, () => {
-      allowMouseUpRef.current = true;
-    });
   }
 
   function handleContextMenu(event: React.MouseEvent) {
@@ -87,12 +81,18 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
       (mouseEvent) => {
         allowMouseUpTriggerRef.current = false;
 
-        if (!allowMouseUpRef.current) {
+        // Ignore the `mouseup` that completes the right click itself: while the
+        // cursor stays within the box around the opening point, this release is
+        // part of the opening gesture and must not close the menu. Moving outside
+        // the box turns it into a press-drag-release that can dismiss the menu.
+        const initialCursorPoint = initialCursorPointRef.current;
+        if (
+          initialCursorPoint &&
+          Math.abs(mouseEvent.clientX - initialCursorPoint.x) <= CONTEXT_MENU_MOVE_THRESHOLD &&
+          Math.abs(mouseEvent.clientY - initialCursorPoint.y) <= CONTEXT_MENU_MOVE_THRESHOLD
+        ) {
           return;
         }
-
-        allowMouseUpTimeout.clear();
-        allowMouseUpRef.current = false;
 
         const mouseUpTarget = getTarget(mouseEvent) as Element | null;
 
@@ -161,18 +161,32 @@ export const ContextMenuTrigger = React.forwardRef(function ContextMenuTrigger(
 
       const target = getTarget(event);
       const targetElement = target as HTMLElement | null;
-      if (
-        contains(triggerRef.current, targetElement) ||
+      const onBackdrop =
         contains(internalBackdropRef.current, targetElement) ||
-        contains(backdropRef.current, targetElement)
-      ) {
+        contains(backdropRef.current, targetElement);
+
+      if (contains(triggerRef.current, targetElement) || onBackdrop) {
         event.preventDefault();
+      }
+
+      // While the menu is open its modal backdrop covers the trigger, so a second
+      // right click lands on the backdrop. Right-clicking again within the box
+      // around the point the menu was opened at toggles it closed.
+      if (onBackdrop) {
+        const initialCursorPoint = initialCursorPointRef.current;
+        if (
+          initialCursorPoint &&
+          Math.abs(event.clientX - initialCursorPoint.x) <= CONTEXT_MENU_MOVE_THRESHOLD &&
+          Math.abs(event.clientY - initialCursorPoint.y) <= CONTEXT_MENU_MOVE_THRESHOLD
+        ) {
+          actionsRef.current?.setOpen(false, createChangeEventDetails(REASONS.triggerPress, event));
+        }
       }
     }
 
     const doc = ownerDocument(triggerRef.current);
     return addEventListener(doc, 'contextmenu', handleDocumentContextMenu);
-  }, [backdropRef, disabled, internalBackdropRef]);
+  }, [actionsRef, backdropRef, disabled, initialCursorPointRef, internalBackdropRef]);
 
   const state: ContextMenuTriggerState = {
     open,

--- a/packages/react/src/context-menu/utils/constants.ts
+++ b/packages/react/src/context-menu/utils/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Maximum distance, in pixels, the cursor may move away from the point where the
+ * context menu opened (on each axis) while still being treated as part of the
+ * opening gesture. Within this tolerance the `mouseup` that follows the right click
+ * is ignored and a second right click toggles the menu closed; moving farther turns
+ * the gesture into a press-drag-release that can dismiss the menu or activate an item.
+ */
+export const CONTEXT_MENU_MOVE_THRESHOLD = 5;

--- a/packages/react/src/menu/item/useMenuItemCommonProps.ts
+++ b/packages/react/src/menu/item/useMenuItemCommonProps.ts
@@ -5,6 +5,7 @@ import { HTMLProps } from '../../internals/types';
 import { MenuStore } from '../store/MenuStore';
 import { REASONS } from '../../internals/reasons';
 import { useContextMenuRootContext } from '../../context-menu/root/ContextMenuRootContext';
+import { CONTEXT_MENU_MOVE_THRESHOLD } from '../../context-menu/utils/constants';
 import type { UseMenuItemMetadata } from './useMenuItem';
 
 export interface UseMenuItemCommonPropsParameters {
@@ -90,8 +91,8 @@ export function useMenuItemCommonProps(params: UseMenuItemCommonPropsParameters)
           if (
             isContextMenu &&
             initialCursorPoint &&
-            Math.abs(event.clientX - initialCursorPoint.x) <= 1 &&
-            Math.abs(event.clientY - initialCursorPoint.y) <= 1
+            Math.abs(event.clientX - initialCursorPoint.x) <= CONTEXT_MENU_MOVE_THRESHOLD &&
+            Math.abs(event.clientY - initialCursorPoint.y) <= CONTEXT_MENU_MOVE_THRESHOLD
           ) {
             return;
           }


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

Reworks the context menu's right-click "open" gesture to be driven by cursor movement instead of a timeout, and adds a toggle-to-close on a second right click.

## What changed

- **Open gesture now uses cursor movement, not a 500ms timeout.** Previously the trailing `mouseup` after a right click could only dismiss the menu after `LONG_PRESS_DELAY` (500ms) had elapsed. Now, while the cursor stays within a small box around the point the menu opened at, the `mouseup` is treated as part of the opening gesture and ignored; moving outside the box turns it into a press-drag-release that can dismiss the menu or activate an item. This matches the cursor-delta logic already used for item activation.
- **Right-clicking again within that box closes the menu (toggle).** Because the modal `InternalBackdrop` covers the trigger while the menu is open, the second right click lands on the backdrop, so this is handled in the document-level `contextmenu` listener.
- **Shared threshold constant.** Added `context-menu/utils/constants.ts` exporting `CONTEXT_MENU_MOVE_THRESHOLD` (currently `5`), following the existing `utils/constants.ts` convention used by other components. It's reused by the item-activation check in `useMenuItemCommonProps`, so trigger-close and item-select use one consistent tolerance.
